### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
         run: ./gradlew build --info
 
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@2.21
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: tzarsmango/memento-cloud-discovery
           username: ${{ secrets.DOCKER_USER }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore